### PR TITLE
Unknown binnewz newsgroup: ab.aa

### DIFF
--- a/sickbeard/providers/binnewz/__init__.py
+++ b/sickbeard/providers/binnewz/__init__.py
@@ -160,6 +160,8 @@ class BinNewzProvider(generic.NZBProvider):
                         newsgroup="alt.binaries.movies.divx.french.reposts"
                     elif newsgroup =="abmdf":
                         newsgroup="alt.binaries.movies.french"
+                    elif newsgroup =="ab.aa":
+                        newsgroup="alt.binaries.aa"
                     else:
                         logger.log(u"Unknown binnewz newsgroup: " + newsgroup, logger.ERROR)
                         continue


### PR DESCRIPTION
Le groupe BinnewZ "ab.aa" n'est pas reconnu  : 

SEARCHQUEUE-BACKLOG-74845 :: Unknown binnewz newsgroup: ab.aa
